### PR TITLE
chore: update staging peer id

### DIFF
--- a/helper/index.js
+++ b/helper/index.js
@@ -17,7 +17,7 @@ import { BITSWAP_V_120 as protocol, Entry, Message, WantList, RawMessage, BlockP
 const targets = {
   local: '/ip4/127.0.0.1/tcp/3000/ws/p2p/bafzbeia6mfzohhrwcvr3eaebk3gjqdwsidtfxhpnuwwxlpbwcx5z7sepei',
   prod: '/dns4/elastic.dag.house/tcp/443/wss/p2p/bafzbeibhqavlasjc7dvbiopygwncnrtvjd2xmryk5laib7zyjor6kf3avm',
-  staging: '/dns4/elastic-staging.dag.house/tcp/443/wss/p2p/bafzbeigjqot6fm3i3yv37wiyybsfblrlsmib7bzlbnkpjxde6fw6b4fvei',
+  staging: '/dns4/elastic-staging.dag.house/tcp/443/wss/p2p/Qmc5vg9zuLYvDR1wtYHCaxjBHenfCNautRwCjG3n5v5fbs',
   dev: '/dns4/elastic-dev.dag.house/tcp/443/wss/p2p/bafzbeia6mfzohhrwcvr3eaebk3gjqdwsidtfxhpnuwwxlpbwcx5z7sepei'
 }
 


### PR DESCRIPTION
it was necessary to update the staging peer id to appease IPNI as at some point dev and staging ended up using the same peerID.

fix the staging peer here so we can run the regression suite

License: MIT